### PR TITLE
Make shellcheck version configurable

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -122,7 +122,7 @@ function install_shellcheck() {
   INSTALL_DIR=${1-$HOME/bin}
   if [ ! -f "$INSTALL_DIR/shellcheck" ]; then
     mkdir -p "$INSTALL_DIR"
-    SHELLCHECK_VERSION="0.3.7-4"
+    SHELLCHECK_VERSION="0.3.7-5"
     wget http://ftp.debian.org/debian/pool/main/s/shellcheck/shellcheck_${SHELLCHECK_VERSION}_amd64.deb
     dpkg -x shellcheck_${SHELLCHECK_VERSION}_amd64.deb "/tmp/shellcheck"
     cp "/tmp/shellcheck/usr/bin/shellcheck" "$INSTALL_DIR/shellcheck"

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -122,7 +122,11 @@ function install_shellcheck() {
   INSTALL_DIR=${1-$HOME/bin}
   if [ ! -f "$INSTALL_DIR/shellcheck" ]; then
     mkdir -p "$INSTALL_DIR"
-    SHELLCHECK_VERSION="0.3.7-5"
+    
+    if [ -z ${SHELLCHECK_VERSION+x} ]; then
+      SHELLCHECK_VERSION="0.3.7-5"
+    fi
+    
     wget http://ftp.debian.org/debian/pool/main/s/shellcheck/shellcheck_${SHELLCHECK_VERSION}_amd64.deb
     dpkg -x shellcheck_${SHELLCHECK_VERSION}_amd64.deb "/tmp/shellcheck"
     cp "/tmp/shellcheck/usr/bin/shellcheck" "$INSTALL_DIR/shellcheck"


### PR DESCRIPTION
Good Morning SignalFx!
I've had tons of problems getting vendor'd builds working with CircleCI so it's really great that you've open sourced this.

One issue I had today was that the version of shellcheck is no longer available which required forking and adjusting circleutil to make it work.

This change I'm putting forward tests whether or not the `SHELLCHECK_VERSION` environment variable is set and if not defaults to the latest (as of this PR 0.3.7-5)
